### PR TITLE
Use `terraform_data` and `azapi_update_resource` to improve the update behavior

### DIFF
--- a/modules/azurerm-ora-exadata-infra/main.tf
+++ b/modules/azurerm-ora-exadata-infra/main.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=4.6.0"
     }
+    azapi = {
+      source = "Azure/azapi"
+      version = "~> 2.0"
+    }
   }
 }
 
@@ -42,6 +46,50 @@ resource "azurerm_oracle_exadata_infrastructure" "this" {
       storage_count,
       customer_contacts,
       maintenance_window
+    ]
+  }
+}
+
+resource "terraform_data" oracle_exadata_infrastructure_keeper {
+  triggers_replace = [{
+    compute_count = var.compute_count,
+    storage_count = var.storage_count,
+    customer_contacts = var.customer_contacts,
+    maintenance_window = {
+      patching_mode = var.maintenance_window.patching_mode
+      preference = var.maintenance_window.preference
+      lead_time_in_weeks = coalesce(var.maintenance_window.lead_time_in_weeks,1) 
+      months = coalesce(var.maintenance_window.months,[])
+      weeks_of_month = coalesce(var.maintenance_window.weeks_of_month,[])
+      days_of_week = coalesce(var.maintenance_window.days_of_week,[])
+      hours_of_day = coalesce(var.maintenance_window.hours_of_day,[])
+    }
+  }]
+}
+
+resource "azapi_update_resource" "oracle_exadata_infrastructure" {
+  type = "Oracle.Database/cloudExadataInfrastructures@2024-06-01"
+  resource_id = azurerm_oracle_exadata_infrastructure.this.id
+  body = {
+    properties = {
+      computeCount = var.compute_count
+      storageCount = var.storage_count
+      customerContacts = var.customer_contacts,
+      maintenanceWindow = {
+        preference = var.maintenance_window.preference
+        months = coalesce(var.maintenance_window.months,[])
+        weeksOfMonth = coalesce(var.maintenance_window.weeks_of_month,[])
+        daysOfWeek = coalesce(var.maintenance_window.days_of_week,[])
+        hoursOfDay = coalesce(var.maintenance_window.hours_of_day,[])
+        leadTimeInWeeks = coalesce(var.maintenance_window.lead_time_in_weeks,1) 
+        patchingMode = var.maintenance_window.patching_mode
+      }
+    }
+  }
+  lifecycle {
+    ignore_changes = all
+    replace_triggered_by = [
+      terraform_data.oracle_exadata_infrastructure_keeper.id
     ]
   }
 }


### PR DESCRIPTION
Hello Oracle,

This pr is inspired by #52, since specified arguments were added into `ignore_changes` list, once the users really want to update them I don't think we can update these fields. This pr HAS NOT been tested because my testing subscription cannot create Oracle resources somehow, but this is a poc to explore whether we can ignore changes from service side, but carry update when users do want to update them. This pr IS NOT completed, it's only shows an idea that maybe we can use this pattern, just for your reference. Please feel free to close it if you think this pr cannot help you.