### PR TITLE
57 update avm quick start template with new azure oci mapping module

### DIFF
--- a/modules/azure-oci-info/README.md
+++ b/modules/azure-oci-info/README.md
@@ -1,0 +1,43 @@
+# azure-oci-info
+
+This module extract OCI identifiers (such as region, tenancy and OCIDs) that assocate with the given Oracle Database@Azure resource.
+
+- Some Azure Verified Modules (AVMs) require Terraform version "~> 3.71" and "~> 3.74", conflicting the AzureRM version requirement of Oracle Exadata ">= 4.9.0"
+- This module is getting information using AZ CLI, instead of AzureRM, to serve as a workaround that works with both AVM-based and AzureRM-based implementation.
+- This module also eliminiated the dependency of JSON mapping data file by deducing information from CLI output directly.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+This module requires Azure CLI, which is already the [prerequisites](https://developer.hashicorp.com/terraform/tutorials/azure-get-started/azure-build#prerequisites) of AzureRM Terraform Provider.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_external"></a> [external](#provider\_external) | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [external_external.az_exadata_infra](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_name"></a> [name](#input\_name) | Name of the resource | `string` | n/a | yes |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of Resource Group | `string` | n/a | yes |
+| <a name="input_resource_type"></a> [resource\_type](#input\_resource\_type) | Supported valid values: cloud-exadata-infrastructure, cloud-vm-cluster, autonomous-database | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_az_cli_cmd"></a> [az\_cli\_cmd](#output\_az\_cli\_cmd) | n/a |
+| <a name="output_oci_compartment_ocid"></a> [oci\_compartment\_ocid](#output\_oci\_compartment\_ocid) | n/a |
+| <a name="output_oci_region"></a> [oci\_region](#output\_oci\_region) | n/a |
+| <a name="output_oci_resource_ocid"></a> [oci\_resource\_ocid](#output\_oci\_resource\_ocid) | n/a |
+| <a name="output_oci_tenant"></a> [oci\_tenant](#output\_oci\_tenant) | n/a |
+<!-- END_TF_DOCS -->

--- a/modules/azure-oci-info/README.md
+++ b/modules/azure-oci-info/README.md
@@ -2,7 +2,7 @@
 
 This module extract OCI identifiers (such as region, tenancy and OCIDs) that assocate with the given Oracle Database@Azure resource.
 
-- Some Azure Verified Modules (AVMs) require Terraform version "~> 3.71" and "~> 3.74", conflicting the AzureRM version requirement of Oracle Exadata ">= 4.9.0"
+- Some Azure Verified Modules (AVMs) require Terraform version "\~> 3.71" and "\~> 3.74", conflicting the AzureRM version requirement of Oracle Exadata ">= 4.9.0"
 - This module is getting information using AZ CLI, instead of AzureRM, to serve as a workaround that works with both AVM-based and AzureRM-based implementation.
 - This module also eliminiated the dependency of JSON mapping data file by deducing information from CLI output directly.
 

--- a/modules/azure-oci-info/README.md
+++ b/modules/azure-oci-info/README.md
@@ -6,11 +6,11 @@ This module extract OCI identifiers (such as region, tenancy and OCIDs) that ass
 - This module is getting information using AZ CLI, instead of AzureRM, to serve as a workaround that works with both AVM-based and AzureRM-based implementation.
 - This module also eliminiated the dependency of JSON mapping data file by deducing information from CLI output directly.
 
-<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-This module requires Azure CLI, which is already the [prerequisites](https://developer.hashicorp.com/terraform/tutorials/azure-get-started/azure-build#prerequisites) of AzureRM Terraform Provider.
+This module requires Azure CLI, which is the [prerequisites of AzureRM Terraform Provider](https://developer.hashicorp.com/terraform/tutorials/azure-get-started/azure-build#prerequisites).
 
+<!-- BEGIN_TF_DOCS -->
 ## Providers
 
 | Name | Version |
@@ -35,7 +35,6 @@ This module requires Azure CLI, which is already the [prerequisites](https://dev
 
 | Name | Description |
 |------|-------------|
-| <a name="output_az_cli_cmd"></a> [az\_cli\_cmd](#output\_az\_cli\_cmd) | n/a |
 | <a name="output_oci_compartment_ocid"></a> [oci\_compartment\_ocid](#output\_oci\_compartment\_ocid) | n/a |
 | <a name="output_oci_region"></a> [oci\_region](#output\_oci\_region) | n/a |
 | <a name="output_oci_resource_ocid"></a> [oci\_resource\_ocid](#output\_oci\_resource\_ocid) | n/a |

--- a/modules/azure-oci-info/main.tf
+++ b/modules/azure-oci-info/main.tf
@@ -17,8 +17,3 @@ data "external" "az_exadata_infra" {
   program = ["sh", "-c", local.az_cli_cmd]
 }
 
-output "az_cli_cmd" {
-  value = local.az_cli_cmd
-}
-
-

--- a/modules/azure-oci-info/main.tf
+++ b/modules/azure-oci-info/main.tf
@@ -1,0 +1,24 @@
+locals {
+  patterns = {
+    "cloud-exadata-infrastructure"="cloudexadatainfrastructures"
+    "cloud-vm-cluster" = "cloudvmclusters"
+    "autonomous-database"= "adbs"
+  }
+  
+  oci_region = regex("(?i:region=)([^?&/]+)",data.external.az_exadata_infra.result.ociUrl)[0]
+  oci_compartment_ocid = regex("(?i:compartmentId=)([^?&/]+)",data.external.az_exadata_infra.result.ociUrl)[0]
+  oci_tenant = regex("(?i:tenant=)([^?&/]+)",data.external.az_exadata_infra.result.ociUrl)[0]
+  oci_resource_ocid = regex("(?i:${local.patterns [var.resource_type]}/)([^?&/]+)",data.external.az_exadata_infra.result.ociUrl)[0]
+  
+  az_cli_cmd = "az oracle-database ${var.resource_type} show --name ${var.name} --resource-group ${var.resource_group_name} | jq 'with_entries(.value |= tostring)'"
+}
+
+data "external" "az_exadata_infra" {
+  program = ["sh", "-c", local.az_cli_cmd]
+}
+
+output "az_cli_cmd" {
+  value = local.az_cli_cmd
+}
+
+

--- a/modules/azure-oci-info/outputs.tf
+++ b/modules/azure-oci-info/outputs.tf
@@ -1,0 +1,15 @@
+output "oci_region" {
+  value = local.oci_region
+}
+
+output "oci_compartment_ocid" {
+  value = local.oci_compartment_ocid
+}
+
+output "oci_tenant" {
+  value = local.oci_tenant
+}
+
+output "oci_resource_ocid" {
+  value = local.oci_resource_ocid
+}

--- a/modules/azure-oci-info/variables.tf
+++ b/modules/azure-oci-info/variables.tf
@@ -1,0 +1,15 @@
+variable "name" {
+  description = "Name of the resource"
+  type = string
+}
+
+variable "resource_group_name" {
+  description = "Name of Resource Group"
+  type = string
+}
+
+variable "resource_type" {
+  description = "Supported valid values: cloud-exadata-infrastructure, cloud-vm-cluster, autonomous-database"
+  type = string
+}
+

--- a/templates/avm-oci-exadata-quickstart/main.oci.tf
+++ b/templates/avm-oci-exadata-quickstart/main.oci.tf
@@ -12,7 +12,7 @@ provider "oci" {
 
 locals {
   # Define OCI Region base on Azure Region   
-  oci_region = module.azure-oci-mapping.region_id
+  oci_region = module.azure-oci-info.oci_region
 
   # Assign OCI tags  
   oci_tags = var.common_tags
@@ -33,10 +33,11 @@ locals {
 }
 
 # Lookup OCI info base on Azure info
-module "azure-oci-mapping" {
-  source   = "../../modules/azure-oci-zone-mapping"
-  location = var.az_region
-  zone     = var.az_zone
+module "azure-oci-info" {
+  source   = "../../modules/azure-oci-info"
+  resource_type = "cloud-exadata-infrastructure"
+  resource_group_name = module.azure-resource-grp.resource_group_name
+  name = module.avm_exadata_infra.resource.name
 }
 
 # Oracle Database DB Home + CDB with default PDB

--- a/templates/avm-oci-exadata-quickstart/terraform.tfvars.template
+++ b/templates/avm-oci-exadata-quickstart/terraform.tfvars.template
@@ -18,7 +18,7 @@ random_suffix_length = 3
 virtual_network_name            = "vnet"
 virtual_network_address_space   = "10.1.0.0/16"
 delegated_subnet_address_prefix = "10.1.1.0/24"
-delegated_subnet_name           = "snet-delegate-oradb"
+delegated_subnet_name           = "sn-oradb"
 
 # AZ Exadata Infrastructure
 exadata_infrastructure_name="real"
@@ -31,7 +31,7 @@ exadata_infrastructure_storage_count=3
 
 # AZ Exadata VM Cluster
 vm_cluster_name                                                  = "vmc"
-vm_cluster_hostname                                              = "dbserver-cug"
+vm_cluster_hostname                                              = "dbsvr"
 vm_cluster_gi_version                                            = "19.0.0.0"
 vm_cluster_cpu_core_count                                        = 4
 vm_cluster_ocpu_count                                            = 2


### PR DESCRIPTION
1. New module 
- azure-oci-info that return OCI info base on AZ CLI output
2. Update avm-oci-exadata-quickstart template
- use azure-oci-info module for getting OCI region
- shorten the default subnet name in terraform.tfvars.template 