### PR TITLE
V0.1.3

### DIFF
--- a/modules/azure-exainfra-vmcluster/README.md
+++ b/modules/azure-exainfra-vmcluster/README.md
@@ -1,4 +1,5 @@
-# azure-exainfra-vmcluster
+# azure-exainfra-vmcluster (obsolete)
+For AzAPI-based reference implementation, please refer to [Azure Verified Modules - avm-res-oracledatabase-cloudexadatainfrastructure](https://registry.terraform.io/modules/Azure/avm-res-oracledatabase-cloudexadatainfrastructure/azurerm/latest)
 
 ## Summary
 

--- a/modules/azure-oci-zone-mapping/README.md
+++ b/modules/azure-oci-zone-mapping/README.md
@@ -1,4 +1,4 @@
-# exadata-limits
+# exadata-limits (obsolete)
 Terraform Template to get info for exadata limits raising.
 
 ## Providers

--- a/modules/azure-oracle-adbs/README.md
+++ b/modules/azure-oracle-adbs/README.md
@@ -1,4 +1,5 @@
-# azure-oracle-adbs
+# azure-oracle-adbs (obsolete)
+For AzAPI-based reference implementation, please refer to [Azure Verified Modules - avm-res-oracledatabase-autonomous](https://github.com/Azure/terraform-azurerm-avm-res-oracledatabase-autonomous)
 
 ## Summary
 

--- a/modules/azure-vmcluster/README.md
+++ b/modules/azure-vmcluster/README.md
@@ -1,4 +1,5 @@
-# azure-vmcluster
+# azure-vmcluster (obsolete)
+For AzAPI-based reference implementation, please refer to [Azure Verified Modules - avm-res-oracledatabase-cloudvmcluster](https://registry.terraform.io/modules/Azure/avm-res-oracledatabase-cloudvmcluster/azurerm/latest)
 
 ## Summary
 

--- a/modules/azurerm-ora-exadata-infra/README.md
+++ b/modules/azurerm-ora-exadata-infra/README.md
@@ -38,7 +38,9 @@ No modules.
 | <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | maintenanceWindow properties | <pre>object({<br/>      patching_mode = string<br/>      preference = string<br/>      lead_time_in_weeks = optional(number)<br/>      months = optional(list(number))<br/>      weeks_of_month = optional(list(number))<br/>      days_of_week =optional(list(number))<br/>      hours_of_day = optional(list(number))<br/>  })</pre> | <pre>{<br/>  "patching_mode": "Rolling",<br/>  "preference": "NoPreference"<br/>}</pre> | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the Exadata Infrastructure at Azure | `string` | `"odaaz-infra"` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of Resource Group in Azure | `string` | `"rg-oradb"` | no |
-| <a name="input_shape"></a> [shape](#input\_shape) | The shape of the Exadata infrastructure resource. e.g. Exadata.X9M | `string` | `"Exadata.X9M"` | no |
+| <a name="input_shape"></a> [shape](#input\_shape) | The shape of the Exadata infrastructure resource. e.g. Exadata.X11M | `string` | `"Exadata.X11M"` | no |
+| <a name="input_storage_server_type"></a> [storage_server_type](#input\_storage_server_type) | The storage server model type of the cloud Exadata infrastructure resource. Null for X9M. Default to X11M-HC for X11M | `string` | `null` | no |
+| <a name="input_database_server_type"></a> [database_server_type](#input\_database_server_type) | The database server model type of the cloud Exadata infrastructure resource. Null for X9M. Default to X11M for X11M | `string` | `null` | no |
 | <a name="input_storage_count"></a> [storage\_count](#input\_storage\_count) | The number of storage servers for the Exadata infrastructure. | `number` | `3` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Resource tags for the Cloud Exadata Infrastructure | `map(string)` | `null` | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | The availablty zone of the Exadata Infrastructure in Azure | `string` | n/a | yes |

--- a/modules/azurerm-ora-exadata-infra/main.tf
+++ b/modules/azurerm-ora-exadata-infra/main.tf
@@ -8,6 +8,11 @@ terraform {
   }
 }
 
+locals {
+  database_server_type = lower(var.shape) == "exadata.x11m" && var.database_server_type == null ? "X11M" : var.database_server_type
+  storage_server_type  = lower(var.shape) == "exadata.x11m" && var.storage_server_type == null ? "X11M-HC" : var.storage_server_type
+}
+
 resource "azurerm_oracle_exadata_infrastructure" "this" {
   # Required 
   resource_group_name = var.resource_group_name
@@ -20,6 +25,8 @@ resource "azurerm_oracle_exadata_infrastructure" "this" {
   shape         = var.shape
   compute_count = var.compute_count
   storage_count = var.storage_count
+  database_server_type = local.database_server_type
+  storage_server_type = local.storage_server_type
 
   # Optional
   customer_contacts  = var.customer_contacts

--- a/modules/azurerm-ora-exadata-infra/variables.tf
+++ b/modules/azurerm-ora-exadata-infra/variables.tf
@@ -34,9 +34,14 @@ variable "storage_count" {
 }
 
 variable "shape" {
-  description = "The shape of the Exadata infrastructure resource. e.g. Exadata.X9M"
   type        = string
-  default     = "Exadata.X9M"
+  default     = "Exadata.X11M"
+  description = "The shape of the infrastructure. Valid value Exadata.X9M and Exadata.X11M"
+
+  validation {
+    condition     = contains(["Exadata.X9M", "Exadata.X11M"], var.shape)
+    error_message = "Valid value Exadata.X9M and Exadata.X11M"
+  }
 }
 
 # Optional
@@ -67,4 +72,16 @@ variable "tags" {
   description = "Resource tags for the Cloud Exadata Infrastructure"
   type        = map(string)
   default     = null
+}
+
+variable "storage_server_type" {
+  type        = string
+  default     = null
+  description = "The storage server model type of the cloud Exadata infrastructure resource. Null for X9M. Default to X11M-HC for X11M"
+}
+
+variable "database_server_type" {
+  type        = string
+  default     = null
+  description = "The database server model type of the cloud Exadata infrastructure resource. Null for X9M. Default to X11M for X11M"
 }

--- a/modules/billing-usage-metrics-validation/README.md
+++ b/modules/billing-usage-metrics-validation/README.md
@@ -1,4 +1,4 @@
-# billing-usage-metrics-validation
+# billing-usage-metrics-validation (obsolete)
 
 ## Summary
 

--- a/modules/connectivity-validation/README.md
+++ b/modules/connectivity-validation/README.md
@@ -1,4 +1,4 @@
-# connectivity-validation
+# connectivity-validation (obsolete)
 ## Summary
 
 Terraform module for CDB/PDB connectivity test.

--- a/templates/az-oci-adbs/README.md
+++ b/templates/az-oci-adbs/README.md
@@ -1,4 +1,5 @@
-# Quickstart OracleDB@Azure (Autonomous Database) with OCI LZ modules (AzAPI)
+# Quickstart OracleDB@Azure Autonomous Database (AzAPI) - (obsolete)
+For AzAPI-based reference implementation, please refer to [Azure Verified Modules - avm-res-oracledatabase-autonomous](https://github.com/Azure/terraform-azurerm-avm-res-oracledatabase-autonomous)
 
 ## Summary
 This is a Terraform Template for provisioning Oracle Database@Azure with the following resources using AzAPI Terraform provider

--- a/templates/az-oci-exa-pdb/README.md
+++ b/templates/az-oci-exa-pdb/README.md
@@ -1,4 +1,6 @@
-# Terraform Template for Provisioning Exa on Azure and Validation
+# Terraform Template for Provisioning Exa on Azure and Validation (obsolete)
+
+For AzAPI-based reference implementation, please refer to [Azure Verified Modules - avm-ptn-odaa](https://registry.terraform.io/modules/Azure/avm-ptn-odaa/azurerm/latest)
 
 ## Providers
 


### PR DESCRIPTION
- Updated azurerm-ora-exadata-infra to support X11M and default to X11M
- Obsolete AzAPI-based module and refer to Azure Verified Modules (AVM) as master reference implementation of AzAPI