### PR TITLE
AVM Template updated for new provider versions

### DIFF
--- a/templates/avm-oci-exadata-quickstart/main.az.tf
+++ b/templates/avm-oci-exadata-quickstart/main.az.tf
@@ -4,13 +4,13 @@ provider "azurerm" {
 }
 
 locals {
-  avm_enable_telemetry = var.avm_enable_telemetry
-  az_tags = var.common_tags
-  az_region   = var.az_region
-  az_zone     = var.az_zone
+  avm_enable_telemetry        = var.avm_enable_telemetry
+  az_tags                     = var.common_tags
+  az_region                   = var.az_region
+  az_zone                     = var.az_zone
   exadata_infrastructure_name = "${var.exadata_infrastructure_name}-${random_string.suffix.result}"
-  vm_cluster_name     = "${var.vm_cluster_name}-${random_string.suffix.result}"
-  vm_cluster_hostname = "${var.vm_cluster_hostname}-${random_string.suffix.result}"
+  vm_cluster_name             = "${var.vm_cluster_name}-${random_string.suffix.result}"
+  vm_cluster_hostname         = "${var.vm_cluster_hostname}-${random_string.suffix.result}"
 }
 
 resource "random_string" "suffix" {
@@ -19,34 +19,48 @@ resource "random_string" "suffix" {
   upper   = false
 }
 
+# # Generate SSH key for testing
+# resource "tls_private_key" "vm_cluster_key" {
+#   algorithm = "RSA"
+#   rsa_bits  = 4096
+# }
+
+# resource "local_file" "private_key" {
+#   filename        = "${path.module}/vm_cluster_private_key.pem"
+#   content         = tls_private_key.vm_cluster_key.private_key_pem
+#   file_permission = "0600"
+# }
+
 # Azure Resource Group
 module "azure-resource-grp" {
-    source = "../../modules/azure-resource-grp"
-    az_region=var.az_region
-    resource_group_name = "oradb"
-    az_tags = local.az_tags
-    new_rg = true
+  source  = "Azure/avm-res-resources-resourcegroup/azurerm"
+  version = "0.2.1"
+
+  name             = var.resource_group
+  location         = var.az_region
+  tags             = local.az_tags
+  enable_telemetry = local.avm_enable_telemetry
 }
 
 # AVM - Exadata Infrastructure
 module "avm_exadata_infra" {
   # Terraform only
-  source  = "Azure/avm-res-oracledatabase-cloudexadatainfrastructure/azurerm" 
-  version = "0.1.0"
-  
+  source  = "Azure/avm-res-oracledatabase-cloudexadatainfrastructure/azurerm"
+  version = "0.3.0"
+
   # OpenTofu or Terraform
   # source  = "github.com/Azure/terraform-azurerm-avm-res-oracledatabase-cloudexadatainfrastructure" 
 
-  depends_on = [ module.azure-resource-grp ]
-  
+  depends_on = [module.azure-resource-grp]
+
   # Mandatory
-  location                             = local.az_region
-  name                                 = local.exadata_infrastructure_name
-  display_name                         = local.exadata_infrastructure_name
-  resource_group_id                    = module.azure-resource-grp.resource_group_id
-  zone                                 = local.az_zone
-  compute_count                        = var.exadata_infrastructure_compute_count
-  storage_count                        = var.exadata_infrastructure_storage_count
+  location          = local.az_region
+  name              = local.exadata_infrastructure_name
+  display_name      = local.exadata_infrastructure_name
+  resource_group_id = module.azure-resource-grp.resource_id
+  zone              = var.az_zone
+  compute_count     = var.exadata_infrastructure_compute_count
+  storage_count     = var.exadata_infrastructure_storage_count
 
   # Optional
   shape                                = var.exadata_infrastructure_shape
@@ -62,58 +76,51 @@ module "avm_exadata_infra" {
 # Azure VNet with delegated subnet
 module "avm_network" {
   source  = "Azure/avm-res-network-virtualnetwork/azurerm"
-  version = "0.2.4"
+  version = "0.17.0"
 
-  depends_on = [ module.azure-resource-grp ]
+  depends_on = [module.azure-resource-grp]
 
-  tags = local.az_tags
-  resource_group_name = module.azure-resource-grp.resource_group_name
-  location            = var.az_region
-  name                = var.virtual_network_name
-  address_space       = [var.virtual_network_address_space]
-
-  subnets = {
-    delegated = {
-      name             = var.delegated_subnet_name
-      address_prefixes = [var.delegated_subnet_address_prefix]
-
-      delegation = [{
-        name = "Oracle.Database/networkAttachments"
-        service_delegation = {
-          name    = "Oracle.Database/networkAttachments"
-          actions = ["Microsoft.Network/networkinterfaces/*", "Microsoft.Network/virtualNetworks/subnets/join/action"]
-
-        }
-      }]
-    }
-  }
+  tags          = local.az_tags
+  parent_id     = module.azure-resource-grp.resource_id
+  location      = var.az_region
+  name          = var.virtual_network_name
+  address_space = [var.virtual_network_address_space]
 }
 
-data "azurerm_subnet" "delegated_subnet" {
-  name                 = var.delegated_subnet_name
-  virtual_network_name = var.virtual_network_name
-  resource_group_name  = module.azure-resource-grp.resource_group_name
+module "delegated_subnet" {
+  source  = "Azure/avm-res-network-virtualnetwork/azurerm//modules/subnet"
+  version = "0.17.0"
 
-  depends_on = [ module.avm_network ]
+  parent_id        = module.avm_network.resource_id
+  name             = var.delegated_subnet_name
+  address_prefixes = [var.delegated_subnet_address_prefix]
+
+  delegation = [{
+    name = "Oracle.Database/networkAttachments"
+    service_delegation = {
+      name    = "Oracle.Database/networkAttachments"
+      actions = ["Microsoft.Network/networkinterfaces/*", "Microsoft.Network/virtualNetworks/subnets/join/action"]
+
+    }
+  }]
 }
 
 # Known Issue - https://docs.oracle.com/en-us/iaas/odexa/odexa-troubleshooting-and-known-issues-exadata-services.html
 resource "time_sleep" "wait_after_deletion" {
   destroy_duration = "30m"
-  depends_on = [module.avm_exadata_infra]
+  depends_on       = [module.avm_exadata_infra]
 }
 
 # AVM - Exadata VM Cluster
 module "avm_exadata_vmc" {
   # Terraform only
-  source  = "Azure/avm-res-oracledatabase-cloudvmcluster/azurerm" 
-  version = "0.1.1"
-  
+  source  = "Azure/avm-res-oracledatabase-cloudvmcluster/azurerm"
+  version = "0.3.2"
+
   # OpenTofu or Terraform
   # source  = "github.com/Azure/terraform-azurerm-avm-res-oracledatabase-cloudvmcluster" 
 
   # VM Cluster details
-  resource_group_id               = module.azure-resource-grp.resource_group_id
   location                        = local.az_region
   cloud_exadata_infrastructure_id = module.avm_exadata_infra.resource_id
   cluster_name                    = local.vm_cluster_name
@@ -124,30 +131,31 @@ module "avm_exadata_vmc" {
   ssh_public_keys                 = var.vm_cluster_ssh_public_keys
 
   # Networking
-  vnet_id                         = module.avm_network.resource_id
-  subnet_id                       = data.azurerm_subnet.delegated_subnet.id
-  backup_subnet_cidr              = var.vm_cluster_backup_subnet_cidr
-  domain                          = "oci${var.delegated_subnet_name}.ocivnet.oraclevcn.com"
+  vnet_id            = module.avm_network.resource_id
+  subnet_id          = module.delegated_subnet.resource_id
+  backup_subnet_cidr = var.vm_cluster_backup_subnet_cidr
+  #domain             = var.delegated_subnet_name
 
   # VM Cluster allocation
-  cpu_core_count                  = var.vm_cluster_cpu_core_count
-  memory_size_in_gbs              = var.vm_cluster_memory_size_in_gbs
-  dbnode_storage_size_in_gbs      = var.vm_cluster_db_node_storage_size_in_gbs
+  cpu_core_count             = var.vm_cluster_cpu_core_count
+  memory_size_in_gbs         = var.vm_cluster_memory_size_in_gbs
+  dbnode_storage_size_in_gbs = var.vm_cluster_db_node_storage_size_in_gbs
 
   # Exadata storage
-  data_storage_size_in_tbs        = var.vm_cluster_data_storage_size_in_tbs
-  data_storage_percentage         = var.vm_cluster_data_storage_percentage
-  is_local_backup_enabled         = var.vm_cluster_is_local_backup_enabled
-  is_sparse_diskgroup_enabled     = var.vm_cluster_is_sparse_diskgroup_enabled
+  data_storage_size_in_tbs    = var.vm_cluster_data_storage_size_in_tbs
+  data_storage_percentage     = var.vm_cluster_data_storage_percentage
+  is_local_backup_enabled     = var.vm_cluster_is_local_backup_enabled
+  is_sparse_diskgroup_enabled = var.vm_cluster_is_sparse_diskgroup_enabled
 
   # Diagnostics Collection
-  is_diagnostic_events_enabled    = var.vm_cluster_data_collection_options_is_diagnostics_events_enabled
-  is_health_monitoring_enabled    = var.vm_cluster_data_collection_options_is_health_monitoring_enabled
-  is_incident_logs_enabled        = var.vm_cluster_data_collection_options_is_incident_logs_enabled
+  is_diagnostic_events_enabled = var.vm_cluster_data_collection_options_is_diagnostics_events_enabled
+  is_health_monitoring_enabled = var.vm_cluster_data_collection_options_is_health_monitoring_enabled
+  is_incident_logs_enabled     = var.vm_cluster_data_collection_options_is_incident_logs_enabled
 
-  tags                            = local.az_tags
-  enable_telemetry                = var.avm_enable_telemetry
-  depends_on = [module.avm_exadata_infra, module.avm_network, module.azure-resource-grp, time_sleep.wait_after_deletion]
+  resource_group_id = module.azure-resource-grp.resource_id
+  tags              = local.az_tags
+  enable_telemetry  = var.avm_enable_telemetry
+  depends_on        = [module.avm_exadata_infra, module.avm_network, module.azure-resource-grp, time_sleep.wait_after_deletion]
 
 }
 

--- a/templates/avm-oci-exadata-quickstart/main.oci.tf
+++ b/templates/avm-oci-exadata-quickstart/main.oci.tf
@@ -19,30 +19,32 @@ locals {
 
   # Oracle Database DB Home + Container Database (CDB) with default Pluggable Database (PDB)
   database_db_home = {
-        db_home_1 = {
-            vm_cluster_id   = module.avm_exadata_vmc.vm_cluster_ocid
-            freeform_tags   = local.oci_tags
-            db_home_source  = var.db_home_source
-            db_home_version = var.db_home_version
-            db_home_name    = "${var.db_home_name}${random_string.suffix.result}"
-            source          = var.db_source
-            db_name         = "${var.db_name}${random_string.suffix.result}"
-            admin_password  = var.db_admin_password
-        }
+    db_home_1 = {
+      vm_cluster_id   = module.avm_exadata_vmc.vm_cluster_ocid
+      freeform_tags   = local.oci_tags
+      db_home_source  = var.db_home_source
+      db_home_version = var.db_home_version
+      db_home_name    = "${var.db_home_name}${random_string.suffix.result}"
+      source          = var.db_source
+      db_name         = "${var.db_name}${random_string.suffix.result}"
+      admin_password  = var.db_admin_password
     }
+  }
 }
 
 # Lookup OCI info base on Azure info
 module "azure-oci-info" {
-  source   = "../../modules/azure-oci-info"
-  resource_type = "cloud-exadata-infrastructure"
-  resource_group_name = module.azure-resource-grp.resource_group_name
-  name = module.avm_exadata_infra.resource.name
+  source              = "../../modules/azure-oci-info"
+  resource_type       = "cloud-exadata-infrastructure"
+  resource_group_name = module.azure-resource-grp.name
+  name                = module.avm_exadata_infra.resource.name
+
+  depends_on = [module.avm_exadata_infra, module.azure-resource-grp]
 }
 
 # Oracle Database DB Home + CDB with default PDB
 module "oci-database-db-home" {
-    source = "../../modules/oci-database-db-home"
-    depends_on       = [module.avm_exadata_vmc]
-    database_db_home = local.database_db_home
+  source           = "../../modules/oci-database-db-home"
+  depends_on       = [module.avm_exadata_vmc]
+  database_db_home = local.database_db_home
 }

--- a/templates/avm-oci-exadata-quickstart/output.tf
+++ b/templates/avm-oci-exadata-quickstart/output.tf
@@ -1,19 +1,19 @@
 output "exadata_infra" {
   description = "Resource object of Exadata Infrastructure from Azure"
-  value = module.avm_exadata_infra.resource
+  value       = module.avm_exadata_infra.resource
 }
 
 output "vm_cluster" {
   description = "Resource object of VM Cluster from Azure"
-  value = module.avm_exadata_vmc.resource
+  value       = module.avm_exadata_vmc.resource
 }
 
 output "vm_cluster_id" {
   description = "OCID of VM Cluster from Azure for OCI"
-  value = module.avm_exadata_vmc.vm_cluster_ocid
+  value       = module.avm_exadata_vmc.vm_cluster_ocid
 }
 
 output "db_home_id" {
   description = "OCID of Oracle Database Home from OCI"
-  value = module.oci-database-db-home.db_home_id
+  value       = module.oci-database-db-home.db_home_id
 }

--- a/templates/avm-oci-exadata-quickstart/terraform.tf
+++ b/templates/avm-oci-exadata-quickstart/terraform.tf
@@ -5,12 +5,12 @@ terraform {
     # https://registry.terraform.io/providers/Azure/azapi/latest/docs
     azapi = {
       source  = "azure/azapi"
-      version = "~> 1.14.0"
+      version = "~> 2.0"
     }
     # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.74"
+      version = ">= 4.0"
     }
     # https://registry.terraform.io/providers/hashicorp/local/latest/docs
     local = {

--- a/templates/avm-oci-exadata-quickstart/variables.tf
+++ b/templates/avm-oci-exadata-quickstart/variables.tf
@@ -9,7 +9,7 @@ variable "common_tags" {
 
 ## Mandatory to randomise namaing for resource group, exadata infra and vmcluster
 variable "random_suffix_length" {
-  type = number
+  type    = number
   default = 3
 }
 
@@ -17,26 +17,26 @@ variable "random_suffix_length" {
 variable "avm_enable_telemetry" {
   description = "This variable controls whether or not telemetry is enabled for the Azure Verified Modules"
   type        = bool
-  default = true
+  default     = true
 }
 
 # Azure Resource Group (azure-resource-grp)
 variable "az_region" {
   description = "The location of the resources on Azure. e.g. useast"
   type        = string
-  default = "useast"
+  default     = "useast"
 }
 
 variable "resource_group" {
   type        = string
   description = "Resource Group Name"
-  default = "rg-oradb"
+  default     = "rg-oradb"
 }
 
 variable "new_rg" {
   type        = bool
   description = "Create new resource group or not"
-  default = true
+  default     = true
 }
 
 # Exadata Infrastructure (azure-exainfra)
@@ -54,37 +54,37 @@ variable "exadata_infrastructure_name" {
 variable "exadata_infrastructure_compute_count" {
   description = "The number of compute servers for the cloud Exadata infrastructure."
   type        = number
-  default = 2
+  default     = 2
 }
 
 variable "exadata_infrastructure_storage_count" {
   description = "The number of storage servers for the Exadata infrastructure."
   type        = number
-  default = 3
+  default     = 3
 }
 
 variable "exadata_infrastructure_shape" {
   description = "The shape of the cloud Exadata infrastructure resource. e.g. Exadata.X9M"
   type        = string
-  default = "Exadata.X9M"
+  default     = "Exadata.X9M"
 }
 
 variable "exadata_infrastructure_maintenance_window_lead_time_in_weeks" {
   description = "Lead time window allows user to set a lead time to prepare for a down time. The lead time is in weeks and valid value is between 1 to 4."
   type        = number
-  default = 1
+  default     = 1
 }
 
 variable "exadata_infrastructure_maintenance_window_preference" {
   description = "The maintenance window scheduling preference.Allowed values are: NO_PREFERENCE, CUSTOM_PREFERENCE."
   type        = string
-  default = "NO_PREFERENCE"
+  default     = "NO_PREFERENCE"
 }
 
 variable "exadata_infrastructure_maintenance_window_patching_mode" {
   description = "Cloud Exadata infrastructure node patching method, either ROLLING or NONROLLING."
   type        = string
-  default = "ROLLING"
+  default     = "ROLLING"
 }
 
 # Azure VNet
@@ -204,7 +204,7 @@ variable "vm_cluster_ssh_public_keys" {
 variable "vm_cluster_backup_subnet_cidr" {
   description = "OCI backup subnet CIDR"
   type        = string
-  default = "192.168.252.0/22"
+  default     = "192.168.252.0/22"
 }
 
 variable "nsg_cidrs" {
@@ -226,28 +226,28 @@ variable "oci_config_file_profile" {
   description = "OCI Config file name"
 }
 
-variable oci_tenancy_ocid {
+variable "oci_tenancy_ocid" {
   type        = string
   description = "OCID of the OCI tenancy"
 }
-variable oci_user_ocid {
+variable "oci_user_ocid" {
   type        = string
   description = "OCID of the OCI user"
 
 }
-variable oci_private_key_path {
+variable "oci_private_key_path" {
   type        = string
   description = "The path (including filename) of the private key"
 
 }
-variable oci_private_key_password {
+variable "oci_private_key_password" {
   type        = string
   description = "Passphrase used for the key, if it's encrypted"
   sensitive   = true
-  default = null
+  default     = null
 }
 
-variable oci_fingerprint {
+variable "oci_fingerprint" {
   type        = string
   description = "Fingerprint for the key pair being used"
 }
@@ -269,8 +269,8 @@ variable "db_home_name" {
 }
 
 variable "enable_database_delete" {
-  type = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Unless enable_database_delete is explicitly set to true, Terraform will not delete the database within the Db Home configuration but rather remove it from the config and state file."
 }
 
@@ -289,5 +289,5 @@ variable "db_admin_password" {
 variable "db_source" {
   type        = string
   description = "The source of the database: Use NONE for creating a new database. Use DB_BACKUP for creating a new database by restoring from a backup. "
-  default = "NONE"
+  default     = "NONE"
 }


### PR DESCRIPTION
Fixes #70 

Updated the [AVM Template](https://github.com/oci-landing-zones/terraform-oci-multicloud-azure/tree/main/templates/avm-oci-exadata-quickstart) with newer versions of AVMs:
- [avm-res-oracledatabase-cloudexadatainfrastructure](https://registry.terraform.io/modules/Azure/avm-res-oracledatabase-cloudexadatainfrastructure/azurerm/latest)
- [terraform-oci-multicloud-azure-tm](https://registry.terraform.io/modules/Azure/avm-res-oracledatabase-cloudvmcluster/azurerm/latest)
- [avm-res-network-virtualnetwork](https://registry.terraform.io/modules/Azure/avm-res-network-virtualnetwork/azurerm/latest)

Note that I was only able to test the Azure side of the scripts, as I do not have the ability to create an OCI API Key.